### PR TITLE
Users can have multiple addresses and only one default address.

### DIFF
--- a/db/db_user_address.py
+++ b/db/db_user_address.py
@@ -3,23 +3,34 @@ from schemas.user_address import AddressBase
 from db.models import DbAddress
 
 
-def add_address(db: Session, request: AddressBase):
+def is_first_address(db: Session, current_user: int):
+    address_count = db.query(DbAddress).filter(DbAddress.user_id == current_user).count()
+    if address_count == 1:
+        return True
+    return False
+
+
+def add_address(db: Session, request: AddressBase, user_id: int):
     new_address = DbAddress(
                     street_name=request.street,
                     house_number=request.house_number,
                     city=request.city,
                     country=request.country,
                     postcode=request.postcode,
-                    user_id=request.user_id
+                    user_id=request.user_id,
+                    default=False
                     )
     db.add(new_address)
     db.commit()
+    if is_first_address(db,user_id):
+        new_address.default = True
+        db.commit()
     db.refresh(new_address)
     return new_address
 
 
-def my_addresses(db: Session, id: int):
-    address = db.query(DbAddress).filter(DbAddress.user_id == id).all()
+def my_addresses(db: Session, user_id: int):
+    address = db.query(DbAddress).filter(DbAddress.user_id == user_id).all()
     if not address:
         raise status.HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Add your address first.")
     return address
@@ -45,6 +56,19 @@ def modify_address(db: Session, id: int, request: AddressBase):
                 })
     db.commit()
     return address.first()
+
+
+def set_default_address(db: Session, id: int, current_user: int):
+    address = db.query(DbAddress).filter(DbAddress.id == id)
+    db.query(DbAddress).filter(DbAddress.user_id == current_user).update({DbAddress.default: False})
+    db.commit()
+    address.update({DbAddress.default: True})
+    db.commit()
+    return address.first()
+
+
+def get_default_address(db: Session):
+    return db.query(DbAddress).filter(DbAddress.default).first()
 
 
 def delete_address(db: Session, id: int):

--- a/db/models.py
+++ b/db/models.py
@@ -1,7 +1,7 @@
 from . import *
 from db.database import Base
 from sqlalchemy import Column
-from sqlalchemy.sql.sqltypes import Integer, String, Float, DateTime, Enum
+from sqlalchemy.sql.sqltypes import Integer, String, Float, DateTime, Enum, Boolean
 from sqlalchemy.sql.schema import ForeignKey
 from sqlalchemy.orm import relationship
 from schemas.bid import BidStatus
@@ -26,6 +26,7 @@ class DbAddress(Base):
     postcode = Column(String)
     house_number = Column(Integer)
     user_id = Column(Integer, ForeignKey('users.id'))
+    default = Column(Boolean, nullable=False)
     user = relationship("DbUser", back_populates="address")
 
 

--- a/schemas/user_address.py
+++ b/schemas/user_address.py
@@ -8,6 +8,7 @@ class AddressBase(BaseModel):
     country: str
     postcode: str
     user_id: int
+    default: bool
 
 
 class AddressPrivateDisplay(BaseModel):

--- a/seed_db/fake_data/addresses_data.py
+++ b/seed_db/fake_data/addresses_data.py
@@ -3,14 +3,14 @@ from . import *
 
 def data(): 
     return [
-        {'street_name': 'Hogeweg', 'city': 'Amsterdam', 'country': 'Netherlands', 'postcode': '1012AB', 'house_number': 85, 'user_id': 1},
-        {'street_name': 'Kerkstraat', 'city': 'Rotterdam', 'country': 'Netherlands', 'postcode': '3011AA', 'house_number': 29, 'user_id': 2},
-        {'street_name': 'Dorpsstraat', 'city': 'Utrecht', 'country': 'Netherlands', 'postcode': '3511AA', 'house_number': 63, 'user_id': 3},
-        {'street_name': 'Lange Voorhout', 'city': 'The Hague', 'country': 'Netherlands', 'postcode': '2514AA', 'house_number': 95, 'user_id': 4},
-        {'street_name': 'Hoofdstraat', 'city': 'Eindhoven', 'country': 'Netherlands', 'postcode': '5611AA', 'house_number': 45, 'user_id': 5},
-        {'street_name': 'Stationsweg', 'city': 'Tilburg', 'country': 'Netherlands', 'postcode': '5011AA', 'house_number': 52, 'user_id': 6},
-        {'street_name': 'Nieuwstraat', 'city': 'Groningen', 'country': 'Netherlands', 'postcode': '9711AA', 'house_number': 76, 'user_id': 7},
-        {'street_name': 'Oudezijds Voorburgwal', 'city': 'Breda', 'country': 'Netherlands', 'postcode': '4811AA', 'house_number': 7, 'user_id': 8},
-        {'street_name': 'Kalverstraat', 'city': 'Nijmegen', 'country': 'Netherlands', 'postcode': '6511AA', 'house_number': 38, 'user_id': 9},
-        {'street_name': 'Zuidwal', 'city': 'Enschede', 'country': 'Netherlands', 'postcode': '7511AA', 'house_number': 92, 'user_id': 10}
+        {'street_name': 'Hogeweg', 'city': 'Amsterdam', 'country': 'Netherlands', 'postcode': '1012AB', 'house_number': 85, 'user_id': 1, 'default':True},
+        {'street_name': 'Kerkstraat', 'city': 'Rotterdam', 'country': 'Netherlands', 'postcode': '3011AA', 'house_number': 29, 'user_id': 2, 'default': True},
+        {'street_name': 'Dorpsstraat', 'city': 'Utrecht', 'country': 'Netherlands', 'postcode': '3511AA', 'house_number': 63, 'user_id': 3, 'default':True},
+        {'street_name': 'Lange Voorhout', 'city': 'The Hague', 'country': 'Netherlands', 'postcode': '2514AA', 'house_number': 95, 'user_id': 4, 'default':True},
+        {'street_name': 'Hoofdstraat', 'city': 'Eindhoven', 'country': 'Netherlands', 'postcode': '5611AA', 'house_number': 45, 'user_id': 5, 'default':True},
+        {'street_name': 'Stationsweg', 'city': 'Tilburg', 'country': 'Netherlands', 'postcode': '5011AA', 'house_number': 52, 'user_id': 6, 'default':True},
+        {'street_name': 'Nieuwstraat', 'city': 'Groningen', 'country': 'Netherlands', 'postcode': '9711AA', 'house_number': 76, 'user_id': 7, 'default':True},
+        {'street_name': 'Oudezijds Voorburgwal', 'city': 'Breda', 'country': 'Netherlands', 'postcode': '4811AA', 'house_number': 7, 'user_id': 8, 'default':True},
+        {'street_name': 'Kalverstraat', 'city': 'Nijmegen', 'country': 'Netherlands', 'postcode': '6511AA', 'house_number': 38, 'user_id': 9, 'default':True},
+        {'street_name': 'Zuidwal', 'city': 'Enschede', 'country': 'Netherlands', 'postcode': '7511AA', 'house_number': 92, 'user_id': 10, 'default':True}
     ]

--- a/seed_db/operations/addresses.py
+++ b/seed_db/operations/addresses.py
@@ -8,6 +8,7 @@ def insert_address(session, address):
                 country=address['country'],
                 postcode=address['postcode'],
                 house_number=address['house_number'],
-                user_id=address['user_id']
+                user_id=address['user_id'],
+                default=address['default']
             ))
     session.commit()


### PR DESCRIPTION
Users can have multiple addresses and only one default address.

I had to restructure the address database to add a boolean flag "default" which is set automatically if the user is adding the first address and after that they can change their default address to any of the addresses they save.

I also modified our fake database with the new entry default in the address database table.