### PR TITLE
address ID path parameter fix

### DIFF
--- a/db/db_user.py
+++ b/db/db_user.py
@@ -89,4 +89,4 @@ def delete_user(db: Session, id: int):
                             detail=f'User with id {id} not found')
     db.delete(user)
     db.commit()
-    return 'ok'
+    return

--- a/db/db_user_address.py
+++ b/db/db_user_address.py
@@ -82,5 +82,5 @@ def delete_address(db: Session, id: int, user_id: int):
                                                                              " change it first!")
     db.delete(address)
     db.commit()
-    return 'ok'
+    return 
 

--- a/routers/user_address_router.py
+++ b/routers/user_address_router.py
@@ -41,9 +41,9 @@ def all_my_addresses(user_id: int,
     return db_user_address.my_addresses(db, current_user.id)
 
 
-@router.get('/{id}', response_model=AddressPrivateDisplay)
+@router.get('/{address_id}', response_model=AddressPrivateDisplay)
 def get_address_by_id(user_id: int,
-                      address_id: Optional[int] = None,
+                      address_id: int,
                       db: Session = Depends(get_db),
                       current_user: UserBase = Depends(get_current_user)):
     if current_user.id != user_id:
@@ -57,7 +57,7 @@ def get_address_by_id(user_id: int,
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You are not authorised.")
 
 
-@router.put('/{id}', response_model=AddressPrivateDisplay)
+@router.put('/{address_id}', response_model=AddressPrivateDisplay)
 def modify_address(request: AddressBase,
                    user_id : int,
                    address_id: int,
@@ -83,7 +83,7 @@ def modify_address(request: AddressBase,
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You are not authorised.")
 
 
-@router.delete('/{id}')
+@router.delete('/{address_id}')
 def delete_address(address_id: int,
                    user_id: int,
                    db: Session = Depends(get_db),

--- a/routers/user_address_router.py
+++ b/routers/user_address_router.py
@@ -10,15 +10,11 @@ router = APIRouter(
 
 
 @router.post('', response_model=AddressPrivateDisplay)
-def add_address(request: AddressBase, user_id : int, db: Session = Depends(get_db),
+def add_address(request: AddressBase, db: Session = Depends(get_db),
                 current_user: UserBase = Depends(get_current_user)):
     """
                Add a new address.
-
-               - **user_id**: ID of the user you want to add address to their profile.
     """
-    if user_id != current_user.id:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You are not authorised.")
     request.user_id = current_user.id
     return db_user_address.add_address(db, request, current_user.id)
 
@@ -41,54 +37,59 @@ def all_my_addresses(user_id: int,
     return db_user_address.my_addresses(db, current_user.id)
 
 
-@router.get('/{address_id}', response_model=AddressPrivateDisplay)
+@router.get('/{id}', response_model=AddressPrivateDisplay)
 def get_address_by_id(user_id: int,
-                      address_id: int,
+                      id: int,
                       db: Session = Depends(get_db),
                       current_user: UserBase = Depends(get_current_user)):
     if current_user.id != user_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You are not authorised.")
     addresses = db_user_address.my_addresses(db, current_user.id)
     try:
-        filtered_address = [adr for adr in addresses if adr.id == address_id]
-        if filtered_address[0].id == address_id:
-            return db_user_address.get_address(db, address_id)
+        filtered_address = [adr for adr in addresses if adr.id == id]
+        if filtered_address[0].id == id:
+            return db_user_address.get_address(db, id)
     except IndexError:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You are not authorised.")
 
 
-@router.put('/{address_id}', response_model=AddressPrivateDisplay)
+@router.put('/{id}', response_model=AddressPrivateDisplay)
 def modify_address(request: AddressBase,
-                   user_id : int,
-                   address_id: int,
+                   id: int,
                    db: Session = Depends(get_db),
-                   change_default: bool = False,
                    current_user: UserBase = Depends(get_current_user)):
     """
-               Modify an existing address or change your default address.
-               When you set the change_default variable to True then by adding the address ID you can set that address ID as your default address.
+               Modify an existing address or change your default address by the address ID.
+               only if the address default is false then you can set it to true to make it your default address.
+               If you intend to modify the sepecifications of your address then you should not change the default value.
 
                - **address_id**: ID of the address to be modified.
     """
+    address = db_user_address.get_address(db, id)
+    user_id = address.user_id
     if user_id != current_user.id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You are not authorised.")
     try:
         addresses = db_user_address.my_addresses(db, current_user.id)
-        filtered_address = [adr for adr in addresses if adr.id == address_id]
-        if filtered_address[0].id == address_id:
-            if change_default:
-                return db_user_address.set_default_address(db, address_id, current_user.id)
-            return db_user_address.modify_address(db, address_id, request)
+        filtered_address = [adr for adr in addresses if adr.id == id]
+        if filtered_address[0].id == id:
+            if address.default:
+                return db_user_address.modify_address(db, id, request)
+            else:
+                if request.default:
+                    return db_user_address.set_default_address(db, id, current_user.id)
+            return db_user_address.modify_address(db, id, request)
     except:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You are not authorised.")
 
 
-@router.delete('/{address_id}')
-def delete_address(address_id: int,
-                   user_id: int,
+@router.delete('/{id}')
+def delete_address(id: int,
                    db: Session = Depends(get_db),
                    current_user: UserBase = Depends(get_current_user)):
-    if current_user.id != user_id:
+    address = db_user_address.get_address(db, id)
+    user_id = address.user_id
+    if current_user.id != address.user_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to delete this address!")
-    return db_user_address.delete_address(db, address_id, user_id)
+    return db_user_address.delete_address(db, id, user_id)
 

--- a/routers/user_router.py
+++ b/routers/user_router.py
@@ -14,17 +14,16 @@ def register_user(request: UserBase, db: Session = Depends(get_db)):
 
 
 @router.get('', response_model= UserPublicDisplay)
-def get_user_publicly(user_id: int, db: Session= Depends(get_db)):
+def get_user_publicly(id: int, db: Session= Depends(get_db)):
     try:
-        return db_user.get_user_by_id(db,user_id)
+        return db_user.get_user_by_id(db,id)
     except:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="This user does not exist.")
 
 @router.get('/{id}',response_model=UserDisplay)
-def get_user(user_id: int, db: Session = Depends(get_db), current_user: UserBase = Depends(get_current_user)):
-    if user_id != current_user.id:
+def get_user(id: int, db: Session = Depends(get_db), current_user: UserBase = Depends(get_current_user)):
+    if id != current_user.id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to see this user")
-    id = current_user.id
     return db_user.get_user_by_id(db, id)
 
 

--- a/schemas/user_address.py
+++ b/schemas/user_address.py
@@ -25,7 +25,6 @@ class AddressPrivateDisplay(BaseModel):
 
 class AddressPublicDisplay(BaseModel):
     id: int
-    postcode: str
     city: str
 
     class Config:

--- a/schemas/user_address.py
+++ b/schemas/user_address.py
@@ -18,6 +18,7 @@ class AddressPrivateDisplay(BaseModel):
     country: str
     postcode: str
     house_number: int
+    default: bool
 
     class Config:
         from_attributes = True

--- a/schemas/users.py
+++ b/schemas/users.py
@@ -26,7 +26,6 @@ class UserDisplay(BaseModel):
 class UserPublicDisplay(BaseModel):
     id: int
     username: str
-    email: str
     address: Optional[AddressPublicDisplay] = None
 
 


### PR DESCRIPTION
**1. removed the redundent query parameters in users and addresses routers.
2. removed ther return 'ok' from the body of the delete methods in both db_users and db_addresses.
3. removed the postcode and email address from the get_user_publicly display models**